### PR TITLE
French Blue Stuff

### DIFF
--- a/Chappeau Resourcepack/assets/minecraft/lang/en_us.json
+++ b/Chappeau Resourcepack/assets/minecraft/lang/en_us.json
@@ -1,4 +1,8 @@
 {
     "item.minecraft.ender_pearl": "Ender Pearl",
-    "item.minecraft.ender_eye": "Eye of Ender"
+    "item.minecraft.ender_eye": "Eye of Ender",
+    "item.minecraft.lapis_lazuli": "French Blue Stuff",
+    "block.minecraft.lapis_block": "Block of French Blue Stuff",
+    "block.minecraft.lapis_ore": "French Blue Stuff Ore",
+    "block.minecraft.deepslate_lapis_ore": "Deepslate French Blue Stuff Ore"
 }


### PR DESCRIPTION
Renames Lapis Lazuli (the item and related blocks) to "French Blue Stuff," as per:

[![ZombieCleo's Hermitcraft S10E01](https://github.com/OpenBagTwo/chappeau/assets/66568922/a22bfed1-180c-4ab3-a511-1834c98dfea7)](https://www.youtube.com/watch?v=ufFo4sPpOhI&t=338s)

## Validation Performed
![2024-02-03_15 24 34](https://github.com/OpenBagTwo/chappeau/assets/66568922/767e8dd9-f0d9-4291-9bb6-668a750fed65)

(performed in Minecraft 1.20.4)